### PR TITLE
reflects the new package of javafx Utils

### DIFF
--- a/javafx/money-fxdemo/src/main/java/org/javamoney/examples/fxdemo/widgets/SamplePage.java
+++ b/javafx/money-fxdemo/src/main/java/org/javamoney/examples/fxdemo/widgets/SamplePage.java
@@ -112,7 +112,7 @@ public class SamplePage extends BorderPane {
 		html.append('\n');
 		html.append("        .syntaxhighlighter {\n");
 		html.append("			overflow: visible;\n");
-		if (com.sun.javafx.Utils.isMac()) {
+		if (com.sun.javafx.util.Utils.isMac()) {
 			html.append("			font: 12px Ayuthaya !important; line-height: 150% !important; \n");
 			html.append("		}\n");
 			html.append("		code { font: 12px Ayuthaya !important; line-height: 150% !important; } \n");

--- a/javafx/money-fxdemo/src/main/java/org/javamoney/examples/fxdemo/widgets/SamplePage.java
+++ b/javafx/money-fxdemo/src/main/java/org/javamoney/examples/fxdemo/widgets/SamplePage.java
@@ -112,7 +112,7 @@ public class SamplePage extends BorderPane {
 		html.append('\n');
 		html.append("        .syntaxhighlighter {\n");
 		html.append("			overflow: visible;\n");
-		if (com.sun.javafx.util.Utils.isMac()) {
+		if (com.sun.javafx.PlatformUtil.isMac()) {
 			html.append("			font: 12px Ayuthaya !important; line-height: 150% !important; \n");
 			html.append("		}\n");
 			html.append("		code { font: 12px Ayuthaya !important; line-height: 150% !important; } \n");


### PR DESCRIPTION
The internal package of the javafx `Utils` class has changed, see https://bitbucket.org/controlsfx/controlsfx/issues/526/comsunjavafxutils-changes-to.
This small fix allows the examples to be compiled with a current JDK 8 ( `>= 1.8.0_60` )